### PR TITLE
Refactor update & delete logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'doorkeeper'
 
 gem 'dotenv-rails'
 
+gem 'acts_as_paranoid'
+
 gem 'bootsnap', '>= 1.4.2', require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    acts_as_paranoid (0.8.1)
+      activerecord (>= 5.2, < 7.1)
+      activesupport (>= 5.2, < 7.1)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     bcrypt (3.1.13)
@@ -202,6 +205,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_paranoid
   bootsnap (>= 1.4.2)
   byebug
   capistrano (~> 3.14.0)

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,16 +1,3 @@
 class ListsController < ApplicationController
   before_action :doorkeeper_authorize!
-
-  def destroy
-    list = List.find(params[:id])
-
-    # only allow 'list' type lists to be deleted, and only if they're empty
-    if list.list_type != 'list' || list.tasks.count != 0
-      return head :unprocessable_entity
-    end
-
-    list.deleted = true
-    list.save!
-    head :no_content
-  end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,9 +1,16 @@
-VALID_LIST_TYPES = ['day', 'list', 'recurring-task-day']
-
 class List < ApplicationRecord
-  after_create :populate_recurring_tasks
+  acts_as_paranoid column: 'deleted', column_type: 'boolean'
 
-  has_many :tasks, dependent: :destroy
+  after_create :populate_recurring_tasks
+  before_update :validate_list_updatable, prepend: true
+  before_destroy :validate_list_deletable, prepend: true
+
+  has_many :tasks
+
+  VALID_LIST_TYPES = ['day', 'list', 'recurring-task-day']
+  CREATABLE_LIST_TYPES = ['list']
+  UPDATABLE_LIST_TYPES = ['list']
+  DELETABLE_LIST_TYPES = ['list']
 
   validates :name, presence: true, uniqueness: { scope: :list_type }
   validates :list_type, inclusion: { in: VALID_LIST_TYPES }
@@ -25,5 +32,26 @@ class List < ApplicationRecord
     recurring_task_list.tasks.each do |recurring_task|
       tasks.create!(description: recurring_task.description)
     end
+  end
+
+  def validate_list_deletable
+    unless DELETABLE_LIST_TYPES.include?(list_type)
+      errors.add :base, "Cannot delete '#{list_type}' lists"
+    end
+    unless tasks.empty?
+      errors.add :base, 'Cannot delete a list with tasks'
+    end
+    throw :abort unless errors.blank?
+  end
+
+  def validate_list_updatable
+    original_list_type = changed_attributes.has_key?(:list_type) ? changed_attributes[:list_type] : list_type
+    unless UPDATABLE_LIST_TYPES.include?(original_list_type)
+      errors.add :base, "Cannot update '#{original_list_type}' lists"
+    end
+    if original_list_type != list_type && !UPDATABLE_LIST_TYPES.include?(list_type)
+      errors.add :base, "Cannot change list_type to #{list_type}"
+    end
+    throw :abort unless errors.blank?
   end
 end

--- a/app/processors/list_processor.rb
+++ b/app/processors/list_processor.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-CREATABLE_LIST_TYPES = ['list']
-UPDATABLE_LIST_TYPES = ['list']
-
 class UncreatableListType < JSONAPI::Exceptions::Error
   attr_reader :list_type
 
@@ -21,61 +18,11 @@ class UncreatableListType < JSONAPI::Exceptions::Error
   end
 end
 
-class InvalidListTypeChange < JSONAPI::Exceptions::Error
-  attr_reader :old_list_type, :new_list_type
-
-  def initialize(old_list_type, new_list_type, error_object_overrides = {})
-    @old_list_type = old_list_type
-    @new_list_type = new_list_type
-    super(error_object_overrides)
-  end
-
-  def errors
-    message = "'#{@old_list_type}' lists cannot be changed to '#{@new_list_type}'"
-    [create_error_object(code: JSONAPI::VALIDATION_ERROR,
-                        status: :unprocessable_entity,
-                        title: message,
-                        detail: "list-type - #{message}",
-                        source: { pointer: '/data/attributes/list-type' })]
-  end
-end
-
-class ImmutableListType < JSONAPI::Exceptions::Error
-  attr_reader :list_type
-
-  def initialize(list_type, error_object_overrides = {})
-    @list_type = list_type
-    super(error_object_overrides)
-  end
-
-  def errors
-    message = "'#{@list_type}' lists cannot have their list_type changed"
-    [create_error_object(code: JSONAPI::VALIDATION_ERROR,
-                        status: :unprocessable_entity,
-                        title: message,
-                        detail: "list-type - #{message}",
-                        source: { pointer: '/data/attributes/list-type' })]
-  end
-end
-
 class ListProcessor < JSONAPI::Processor
   before_create_resource do
     list_type = params[:data][:attributes][:list_type]
-    unless CREATABLE_LIST_TYPES.include?(list_type)
+    unless List::CREATABLE_LIST_TYPES.include?(list_type)
       raise UncreatableListType.new(list_type)
-    end
-  end
-
-  before_replace_fields do
-    resource_id = params[:resource_id]
-    resource = resource_klass.find_by_key(resource_id, context: context)
-    unless UPDATABLE_LIST_TYPES.include?(resource.list_type)
-      raise ImmutableListType.new(resource.list_type)
-    end
-
-    new_list_type = params[:data][:attributes][:list_type]
-    unless UPDATABLE_LIST_TYPES.include?(new_list_type)
-      raise InvalidListTypeChange.new(resource.list_type, new_list_type)
     end
   end
 end

--- a/app/resources/list_resource.rb
+++ b/app/resources/list_resource.rb
@@ -3,10 +3,6 @@ class ListResource < JSONAPI::Resource
 
   has_many :tasks
 
-  def self.records(options = {})
-    List.active
-  end
-
   filter :list_type
   filter :name
   filter :date,

--- a/test/factories/lists.rb
+++ b/test/factories/lists.rb
@@ -2,10 +2,15 @@ FactoryBot.define do
   factory :list do
     name { 'A List' }
     list_type { 'list' }
-  end
 
-  trait :day do
-    list_type { 'day' }
-    name { DateTime.now.strftime('%Y-%m-%d') }
+    trait :day do
+      list_type { 'day' }
+      name { DateTime.now.strftime('%Y-%m-%d') }
+    end
+
+    trait :recurring_task_day do
+      list_type { 'recurring-task-day' }
+      name { DateTime.now.strftime('%A') }
+    end
   end
 end

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -38,7 +38,7 @@ class TasksTest < ActionDispatch::IntegrationTest
   test "filters by overdue tasks" do
     last_week = 1.week.ago
 
-    last_week_list = create(:list, list_type: 'day', name: last_week.strftime('%Y-%m-%d'))
+    last_week_list = create(:list, :day, name: last_week.strftime('%Y-%m-%d'))
     create_list(:task, 5, done: false, list: last_week_list)
     create_list(:task, 6, done: true, list: last_week_list)
 


### PR DESCRIPTION
Add the [acts_as_paranoid](https://github.com/ActsAsParanoid/acts_as_paranoid) gem to handle soft deletion, instead of doing it ourselves. Additionally refactor the logic for preventing lists from being updated when they shouldn't, or deleted when they shouldn't, to use Rails' ActiveRecord callbacks & validation logic instead of custom logic in a JSONAPI::Processor.