### PR TITLE
Add 'due_before' filter

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -19,4 +19,8 @@ class Task < ApplicationRecord
   def self.by_plaintext_description
     order(Arel.sql("REGEXP_REPLACE(description, '[^A-Za-z0-9]', '', 'g')"))
   end
+
+  def self.due_before(date)
+    joins(:list).where(done: false).where("lists.list_type = 'day' and to_date(lists.name, 'YYYY-MM-DD') < to_date(?, 'YYYY-MM-DD')", date)
+  end
 end

--- a/app/resources/task_resource.rb
+++ b/app/resources/task_resource.rb
@@ -12,6 +12,11 @@ class TaskResource < JSONAPI::Resource
       records.overdue
     }
 
+  filter :due_before,
+    apply: ->(records, values, _options) {
+      records.due_before(values[0])
+    }
+
   def self.apply_sort(records, order_options, options)
     if order_options.any?
       order_options.each_pair do |field, direction|

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -34,4 +34,26 @@ class TaskTest < ActiveSupport::TestCase
 
     assert_equal Task.overdue, overdue_tasks
   end
+
+  test '.due_before returns list of unfinished tasks on a "day" list with a date before the given one' do
+    past_lists = [
+      create(:list, name: 1.month.ago, list_type: :day),
+      create(:list, name: 2.weeks.ago, list_type: :day),
+      create(:list, name: 3.days.ago, list_type: :day)
+    ]
+    other_lists = [
+      create(:list, name: Time.current, list_type: :day),
+      create(:list, name: 1.day.from_now, list_type: :day),
+      create(:list, name: 1.month.from_now, list_type: :day)
+    ]
+
+    overdue_tasks = past_lists.map { |l| create(:task, list: l, done: false) }
+    past_lists.each { |l| create(:task, list: l, done: true )}
+    other_lists.each do |l|
+      create(:task, list: l, done: false)
+      create(:task, list: l, done: true)
+    end
+
+    assert_equal Task.due_before(Time.current), overdue_tasks
+  end
 end


### PR DESCRIPTION
Similar to `overdue` but takes the date as a parameter instead of using the server date - useful when the server & client aren't the same time zone.